### PR TITLE
(Hopefully) Adds the current title & link to the page to the New Issu…

### DIFF
--- a/source/layouts/_contribute.erb
+++ b/source/layouts/_contribute.erb
@@ -6,7 +6,7 @@
 	<div class="buttons">
   	<a class="btn" title="Publicly archived list" href="mailto:<%= site['email'] %>?subject=%5b<%= site['title'].gsub(' ', '%20') %>%20Input%20%3a%20<%= current_page.data.title.gsub(' ', '%20') %>%5d">E-mail</a>
     <a class="btn" href="https://github.com/w3c/<%= site['github'] %>/blob/master/source/<%= current_page.data.path %>">Fork &amp; edit on GitHub</a>
-  	<a class="btn" href="https://github.com/w3c/<%= site['github'] %>/issues/new">New GitHub Issue</a>
+  	<a class="btn" href="https://github.com/w3c/<%= site['github'] %>/issues/new?title=[<%= current_page.data.title.gsub(' ', '%20') %>]&body=This%20is%20a%20comment%20related%20to%20the%20page%20[<%= current_page.data.title.gsub(' ', '%20') %>](<%= current_page.url %>)">New GitHub Issue</a>
 	</div>
 </aside>
 <% end %>


### PR DESCRIPTION
…e created on Github

Please test locally when you get time for it. The aim is to prefill the title and body with something vaguely meaningful to help people comment on individual pages more easily.
