### PR TITLE
Fix GitHub Page URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ Don’t forget to add some descriptive text at the bottom that comments your cha
 
 Note that the changes are not immediately reflected on any page. If you want to see your changes in HTML that way is more technical and is described briefly in the following part of the document. But there is a preview button in the editor that gives you a fairly good example of how the rendered HTML will look like.
 
-[GHPage]:http://w3c.github.io/wai-quick-start/
+[GHPage]:https://w3c.github.io/wai-dynamic-planning/


### PR DESCRIPTION
The URL should be https://w3c.github.io/wai-dynamic-planning/ instead of https://github.com/w3c/wai-quick-start
